### PR TITLE
Add shadow to top-navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     <!-- End Side Drawer -->
 
     <!-- Begin Top Navbar -->
-    <nav class="navbar navbar-dark bg-primary fixed-top">
+    <nav class="navbar navbar-dark bg-primary fixed-top shadow">
       <button class="navbar-toggler" type="button" onclick="openSideDrawer()">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Fixes #1

**Summary**:
- Add Bootstrap 4.5 shadow class to top-navbar component

**Test**:
1. Open `index.html`in your browser
1. The top navbar should have a regular-sized shadow underneath

**Issues**:
- If you're using the Bootstrap 4.5 CDN, shadows are disabled by default. You can enable them with your own installation of Bootstrap via the `$enable-shadows` variable. ([Source](https://getbootstrap.com/docs/4.5/utilities/shadows/))