### PR TITLE
Increase vertical padding on side drawer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
         </div>
         <!-- Side Drawer Links -->
         <ul id="links" class="list-group" onclick="closeSideDrawer()">
-          <a id="link-structure" href="#structure" class="list-group-item list-group-item-action border-0 rounded-0 active">Structure</a>
-          <a id="link-css" href="#css" class="list-group-item list-group-item-action border-0 rounded-0">CSS</a>
-          <a id="link-javascript" href="#javascript" class="list-group-item list-group-item-action border-0 rounded-0">JavaScript</a>
-          <a id="link-customization" href="#customization" class="list-group-item list-group-item-action border-0 rounded-0">Customization</a>
+          <a id="link-structure" href="#structure" class="list-group-item list-group-item-action py-3 border-0 rounded-0 active">Structure</a>
+          <a id="link-css" href="#css" class="list-group-item list-group-item-action py-3 border-0 rounded-0">CSS</a>
+          <a id="link-javascript" href="#javascript" class="list-group-item list-group-item-action py-3 border-0 rounded-0">JavaScript</a>
+          <a id="link-customization" href="#customization" class="list-group-item list-group-item-action py-3 border-0 rounded-0">Customization</a>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2 

**Summary**:
- Add py-3 class to side drawer links

**Test**:
1. Open `index.html`
1. Open the Side Bar and check that there's more vertical room in-between links

**Issues**:
- N/A