### PR TITLE
Replace side drawer header text with image and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ I made use of the following during the course of development:
 - https://stackoverflow.com/questions/44908329/copy-text-innerhtml-of-element-to-clipboard
 - https://www.w3schools.com/howto/howto_js_collapse_sidepanel.asp
 - https://www.w3schools.com/howto/howto_js_active_element.asp
+- https://icons8.com
+- https://picsum.photos/

--- a/index.html
+++ b/index.html
@@ -19,10 +19,11 @@
     <div id="side-drawer" class="position-fixed">
       <div class="h-100 bg-white">
         <!-- Side Drawer Title -->
-        <div class="p-4 bg-dark">
-          <a href="index.html">
-            <h1 class="text-white">Home</h1>
+        <div class="p-4 text-center bg-dark">
+          <a href="index.html" data-toggle="tooltip" data-placement="right" title="Home">
+            <img src="https://picsum.photos/100" class="rounded-circle mb-3" style="height: 100px">
           </a>
+          <p class="lead text-info mb-0">email@yourapp.com</p>
         </div>
         <!-- Side Drawer Links -->
         <ul id="links" class="list-group" onclick="closeSideDrawer()">
@@ -235,6 +236,11 @@ window.closeSideDrawer = closeSideDrawer;
     <script src="https://code.jquery.com/jquery-4 p-md-5.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+      })
+    </script>
 
     <!-- Side Drawer JS -->
     <script src="public/js/side_drawer.js"></script>


### PR DESCRIPTION
Fixes #7 

**Summary**:
- Replace side drawer header text with image and email
- Update README.md to include new references

**Test**:
1. Open `index.html`
1. Open the Side Drawer
1. The old "Home" header text should be replaced with a random [image](https://picsum.photos/) and a dummy email below it

**Issues**:
- N/A