### PR TITLE
Add lead class to top-navbar project title

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       <button class="navbar-toggler" type="button" onclick="openSideDrawer()">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <span class="navbar-text">
+      <span class="navbar-text lead">
         Project Name &copy; 2020
       </span>
     </nav>


### PR DESCRIPTION
Fixes #9 

**Summary**:
- Add lead class to project title in top-navbar

**Test**:
1. Open `index.html`
1. Check that the project title at the right side of the top-navbar component uses the `lead` Bootstrap class

**Issues**:
- N/A
