### PR TITLE
Replace navbar-toggler button class with btn

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 
     <!-- Begin Top Navbar -->
     <nav class="navbar navbar-dark bg-primary fixed-top shadow">
-      <button class="navbar-toggler" type="button" onclick="openSideDrawer()">
+      <button class="btn btn-primary mb-1" type="button" onclick="openSideDrawer()">
         <span class="navbar-toggler-icon"></span>
       </button>
       <span class="navbar-text lead">


### PR DESCRIPTION
Fixes #5 

**Summary**:
- Replace navbar-toggler class with btn class

**Test**:
1. Open `index.html`
1. Check the top-navbar component. The menu button at the left should no longer look like this:
![Screen Shot 2020-05-24 at 12 20 19 PM](https://user-images.githubusercontent.com/25632004/82745647-6e1b1280-9db9-11ea-930b-bb4ca063b174.png)
But rather, like this:
![Screen Shot 2020-05-24 at 12 20 32 PM](https://user-images.githubusercontent.com/25632004/82745655-812de280-9db9-11ea-9863-298a26298e08.png)

**Issues**:
- N/A
