### PR TITLE
Publish v1.0.1 to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bootstrap-side-drawer",
+  "version": "1.0.1",
+  "description": "A simple Bootstrap 4 implementation of a side drawer navigation component",
+  "main": "index.html",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielflachica/Bootstrap-4-Side-Drawer.git"
+  },
+  "keywords": [
+    "Bootstrap",
+    "Side Drawer"
+  ],
+  "author": "Daniel Lachica",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/danielflachica/Bootstrap-4-Side-Drawer/issues"
+  },
+  "homepage": "https://github.com/danielflachica/Bootstrap-4-Side-Drawer#readme"
+}


### PR DESCRIPTION
Fixes #19

**Summary**:
- Create package.json via `npm init`
- Publish package to npm via `npm publish`
- Reference: https://zellwk.com/blog/publish-to-npm/

**Test**:
1. On your local machine, run `npm install bootstrap-side-drawer`

**Issues**:
- I'll need to manually update the version dependency every time there's a new release
